### PR TITLE
Placeholder api support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/*
 .idea/
 !target/**.jar
 **.iml
+/.idea/
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/*
 **.iml
 /.idea/
 /target/
+LitePlaytimeRewards.iml

--- a/LitePlaytimeRewards.iml
+++ b/LitePlaytimeRewards.iml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
@@ -28,5 +37,6 @@
     <orderEntry type="library" name="Maven: junit:junit:4.10" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.1" level="project" />
     <orderEntry type="library" name="Maven: net.ess3:FlattenedProvider:2.16.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: me.clip:placeholderapi:2.9.2" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.backtobedrock</groupId>
     <artifactId>LitePlaytimeRewards</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -19,6 +19,10 @@
         <repository>
             <id>ess-repo</id>
             <url>https://ci.ender.zone/plugin/repository/everything/</url>
+        </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
     <build>
@@ -47,6 +51,12 @@
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>2.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.9.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/com/backtobedrock/LitePlaytimeRewards/LitePlaytimeRewards.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/LitePlaytimeRewards.java
@@ -37,11 +37,20 @@ public class LitePlaytimeRewards extends JavaPlugin implements Listener {
     private Rewards rewards;
     private ServerData serverData;
     private LitePlaytimeRewardsCommands commands;
+    private boolean papiEnabled = false;
 
     @Override
     public void onEnable() {
         //register Reward for serialization
         ConfigurationSerialization.registerClass(Reward.class);
+
+        // Small check to make sure that PlaceholderAPI is installed
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            this.getLogger().info("Placeholder API found, placeholders supported.");
+            papiEnabled = true;
+        } else {
+            this.getLogger().info("PlaceholderAPI not found.");
+        }
 
         //initialize plugin
         this.initialize();

--- a/src/com/backtobedrock/LitePlaytimeRewards/LitePlaytimeRewards.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/LitePlaytimeRewards.java
@@ -9,11 +9,13 @@ import com.backtobedrock.LitePlaytimeRewards.utils.ConfigUpdater;
 import com.backtobedrock.LitePlaytimeRewards.utils.ConfigUtils;
 import com.backtobedrock.LitePlaytimeRewards.utils.Metrics;
 import com.backtobedrock.LitePlaytimeRewards.utils.UpdateChecker;
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.ess3.api.IEssentials;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -37,7 +39,7 @@ public class LitePlaytimeRewards extends JavaPlugin implements Listener {
     private Rewards rewards;
     private ServerData serverData;
     private LitePlaytimeRewardsCommands commands;
-    private boolean papiEnabled = false;
+    private static boolean papiEnabled = false;
 
     @Override
     public void onEnable() {
@@ -47,7 +49,7 @@ public class LitePlaytimeRewards extends JavaPlugin implements Listener {
         // Small check to make sure that PlaceholderAPI is installed
         if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             this.getLogger().info("Placeholder API found, placeholders supported.");
-            papiEnabled = true;
+            LitePlaytimeRewards.papiEnabled = true;
         } else {
             this.getLogger().info("PlaceholderAPI not found.");
         }
@@ -63,6 +65,20 @@ public class LitePlaytimeRewards extends JavaPlugin implements Listener {
         metrics.addCustomChart(new Metrics.SimplePie("reward_count", () -> Integer.toString(this.rewards.getAll().size())));
 
         super.onEnable();
+    }
+
+    /**
+     * Resolves PAPI placeholders.
+     *
+     * @param player The player object.
+     * @param text The text which may contain placeholders.
+     * @return The final text.
+     */
+    public static String replacePlaceholders(Player player, String text) {
+        if(papiEnabled) {
+            return PlaceholderAPI.setPlaceholders(player, text);
+        }
+        return text;
     }
 
     @Override

--- a/src/com/backtobedrock/LitePlaytimeRewards/guis/CustomHolder.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/guis/CustomHolder.java
@@ -120,8 +120,7 @@ public class CustomHolder implements InventoryHolder {
     public Inventory getInventory() {
         if (this.inventory == null) {
             this.inventory = Bukkit.createInventory(this, this.size, this.title);
-
-            this.icons.forEach((key, value) -> this.inventory.setItem(key, value.itemStack));
+            this.icons.forEach((key, value) -> this.inventory.setItem(key, Icon.cloneForGUI(value.itemStack)));
         }
         return this.inventory;
     }

--- a/src/com/backtobedrock/LitePlaytimeRewards/guis/Icon.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/guis/Icon.java
@@ -2,7 +2,9 @@ package com.backtobedrock.LitePlaytimeRewards.guis;
 
 import com.backtobedrock.LitePlaytimeRewards.guis.clickActions.ClickAction;
 import com.backtobedrock.LitePlaytimeRewards.models.Reward;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
 
@@ -16,6 +18,15 @@ public class Icon {
         this.itemStack = itemStack;
         this.clickActions = ca;
         this.reward = reward;
+    }
+
+    public static ItemStack cloneForGUI(ItemStack itemStack) {
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        ItemMeta copyItemMeta = itemMeta.clone();
+        copyItemMeta.setDisplayName(PlaceholderAPI.setPlaceholders(null, itemMeta.getDisplayName()));
+        ItemStack copyStack = itemStack.clone();
+        copyStack.setItemMeta(copyItemMeta);
+        return copyStack;
     }
 
     public List<ClickAction> getClickActions() {

--- a/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
@@ -148,9 +148,6 @@ public class Reward implements ConfigurationSerializable {
                 : this.plugin.getMessages().getNextRewardNever().stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList())
                 : this.plugin.getMessages().getNextRewardNoPermission().stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList()));
 
-        Bukkit.getLogger().info(">>>> --------- DESCRIPTION ---------- <<<<");
-        description.forEach(d -> Bukkit.getLogger().info(">>>> " + d));
-
         return description;
     }
 

--- a/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
@@ -2,7 +2,6 @@ package com.backtobedrock.LitePlaytimeRewards.models;
 
 import com.backtobedrock.LitePlaytimeRewards.LitePlaytimeRewards;
 import com.backtobedrock.LitePlaytimeRewards.runnables.NotifyBossBar;
-import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import org.bukkit.Bukkit;
@@ -133,21 +132,21 @@ public class Reward implements ConfigurationSerializable {
 
     public List<String> getRewardsGUIDescription(OfflinePlayer player) {
         List<String> description = (new ArrayList<>(this.cReward.getDisplayDescription()));
-        description = description.stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList());
+        description = description.stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList());
 
         if (description.size() > 0) {
             description.add(0, "§f----");
         }
 
         description.addAll(0, this.plugin.getMessages().getRewardInfo(this.getAmountRedeemed(), this.getAmountPending())
-                .stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList()));
+                .stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList()));
         description.add("§f----");
         int nextReward = this.getTimeTillNextReward().get(0);
         description.addAll(player.isOnline() && (((Player) player).hasPermission("liteplaytimerewards.reward." + this.cReward.getId()) || !this.cReward.isUsePermission())
                 ? this.isEligible()
-                ? this.plugin.getMessages().getNextReward(nextReward).stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList())
-                : this.plugin.getMessages().getNextRewardNever().stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList())
-                : this.plugin.getMessages().getNextRewardNoPermission().stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList()));
+                ? this.plugin.getMessages().getNextReward(nextReward).stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList())
+                : this.plugin.getMessages().getNextRewardNever().stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList())
+                : this.plugin.getMessages().getNextRewardNoPermission().stream().map(l -> LitePlaytimeRewards.replacePlaceholders(player.getPlayer(), l)).collect(Collectors.toList()));
 
         Bukkit.getLogger().info(">>>> --------- DESCRIPTION ---------- <<<<");
         description.forEach(d -> Bukkit.getLogger().info(">>>> " + d));
@@ -189,7 +188,7 @@ public class Reward implements ConfigurationSerializable {
                     pending++;
                 } else {
                     this.cReward.getCommands().forEach(j -> {
-                        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), PlaceholderAPI.setPlaceholders(player, j));
+                        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), LitePlaytimeRewards.replacePlaceholders(player, j));
                     });
 
                     this.setAmountRedeemed(this.amountRedeemed + 1);
@@ -202,7 +201,7 @@ public class Reward implements ConfigurationSerializable {
                 }
             }
 
-            message = PlaceholderAPI.setPlaceholders(player, message);
+            message = LitePlaytimeRewards.replacePlaceholders(player, message);
             if (!message.equals("") && amount > 0) {
                 switch (this.cReward.getNotificationType()) {
                     case CHAT:
@@ -226,8 +225,8 @@ public class Reward implements ConfigurationSerializable {
     }
 
     private void notifyUsers(Player plyr, boolean broadcast) {
-        String notification = PlaceholderAPI.setPlaceholders(plyr, this.cReward.getNotification());
-        String broadcastNotification = PlaceholderAPI.setPlaceholders(plyr, this.cReward.getBroadcastNotification());
+        String notification = LitePlaytimeRewards.replacePlaceholders(plyr, this.cReward.getNotification());
+        String broadcastNotification = LitePlaytimeRewards.replacePlaceholders(plyr, this.cReward.getBroadcastNotification());
 
         Collection<Player> players = new ArrayList<>();
 

--- a/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
+++ b/src/com/backtobedrock/LitePlaytimeRewards/models/Reward.java
@@ -2,6 +2,7 @@ package com.backtobedrock.LitePlaytimeRewards.models;
 
 import com.backtobedrock.LitePlaytimeRewards.LitePlaytimeRewards;
 import com.backtobedrock.LitePlaytimeRewards.runnables.NotifyBossBar;
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import org.bukkit.Bukkit;
@@ -132,19 +133,24 @@ public class Reward implements ConfigurationSerializable {
 
     public List<String> getRewardsGUIDescription(OfflinePlayer player) {
         List<String> description = (new ArrayList<>(this.cReward.getDisplayDescription()));
+        description = description.stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList());
 
         if (description.size() > 0) {
             description.add(0, "§f----");
         }
 
-        description.addAll(0, this.plugin.getMessages().getRewardInfo(this.getAmountRedeemed(), this.getAmountPending()));
+        description.addAll(0, this.plugin.getMessages().getRewardInfo(this.getAmountRedeemed(), this.getAmountPending())
+                .stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList()));
         description.add("§f----");
         int nextReward = this.getTimeTillNextReward().get(0);
         description.addAll(player.isOnline() && (((Player) player).hasPermission("liteplaytimerewards.reward." + this.cReward.getId()) || !this.cReward.isUsePermission())
                 ? this.isEligible()
-                ? this.plugin.getMessages().getNextReward(nextReward)
-                : this.plugin.getMessages().getNextRewardNever()
-                : this.plugin.getMessages().getNextRewardNoPermission());
+                ? this.plugin.getMessages().getNextReward(nextReward).stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList())
+                : this.plugin.getMessages().getNextRewardNever().stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList())
+                : this.plugin.getMessages().getNextRewardNoPermission().stream().map(l -> PlaceholderAPI.setPlaceholders(player, l)).collect(Collectors.toList()));
+
+        Bukkit.getLogger().info(">>>> --------- DESCRIPTION ---------- <<<<");
+        description.forEach(d -> Bukkit.getLogger().info(">>>> " + d));
 
         return description;
     }
@@ -183,7 +189,7 @@ public class Reward implements ConfigurationSerializable {
                     pending++;
                 } else {
                     this.cReward.getCommands().forEach(j -> {
-                        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), j.replaceAll("%player%", plyr.getName()));
+                        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), PlaceholderAPI.setPlaceholders(player, j));
                     });
 
                     this.setAmountRedeemed(this.amountRedeemed + 1);
@@ -196,6 +202,7 @@ public class Reward implements ConfigurationSerializable {
                 }
             }
 
+            message = PlaceholderAPI.setPlaceholders(player, message);
             if (!message.equals("") && amount > 0) {
                 switch (this.cReward.getNotificationType()) {
                     case CHAT:
@@ -219,8 +226,8 @@ public class Reward implements ConfigurationSerializable {
     }
 
     private void notifyUsers(Player plyr, boolean broadcast) {
-        String notification = this.cReward.getNotification().replaceAll("%player%", plyr.getName());
-        String broadcastNotification = this.cReward.getBroadcastNotification().replaceAll("%player%", plyr.getName());
+        String notification = PlaceholderAPI.setPlaceholders(plyr, this.cReward.getNotification());
+        String broadcastNotification = PlaceholderAPI.setPlaceholders(plyr, this.cReward.getBroadcastNotification());
 
         Collection<Player> players = new ArrayList<>();
 


### PR DESCRIPTION
I added support for PAPI so that placeholders of all kinds can be used throughout the config of LitePlaytimeRewards. So instead of just being able to use the placeholder %player%, there are now hundreds of placeholders available, which I really needed for some commands that I run in my rewards.